### PR TITLE
Enable GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+# Based on gitbucket-pages-plugin:
+#   https://github.com/gitbucket/gitbucket-pages-plugin/blob/master/.github/workflows/build.yml
+# Which is licensed under the Apache License:
+#   https://github.com/gitbucket/gitbucket-pages-plugin/blob/master/LICENSE
+
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [8, 11]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-sbt-libs
+      with:
+        path: |
+          ~/.ivy2/cache
+          ~/.sbt
+          ~/.coursier
+        key: build-${{ env.cache-name }}-${{ hashFiles('build.sbt') }}    
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Download PlantUML
+      run: sbt downloadPlantuml
+    - name: Test
+      run: sbt test
+    - name: Assembly
+      run: sbt assembly
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: gitbucket-plantuml-plugin-java${{ matrix.java }}-${{ github.sha }}
+        path: ./target/scala-2.13/*.jar

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ useJCenter := true
 
 lazy val downloadPlantuml = taskKey[Unit]("Download the PlantUML ASL Version.")
 downloadPlantuml := {
-  val url = "https://svwh.dl.sourceforge.net/project/plantuml/1.2020.18/plantuml-jar-asl-1.2020.18.zip"
+  val url = "https://downloads.sourceforge.net/project/plantuml/1.2021.9/plantuml-jar-asl-1.2021.9.zip"
   if (java.nio.file.Files.notExists(new File("lib/plantuml.jar").toPath())) {
     println(url)
     IO.unzipURL(new URL(url), new File("lib"))


### PR DESCRIPTION
The following changes are included in this pull request:

* Added a CI workflow for GitHub Actions.
  * Thanks to the one of [gitbucket-pages-plugin](https://github.com/gitbucket/gitbucket-pages-plugin).
  * This workflow builds after passing tests and makes the products available for download as an artifacts.
  * I am not familiar with Scala, so there may be some unnecessary descriptions included.
* I changed the download URL for PlantUML.
  * It is because the current URL seemed to have expired.
  * I have also upgraded the version of PlantUML.

Relates to: #26 