### PR TITLE
build: Updated PlantUML dependency to 1.2025.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "gitbucket-plantuml-plugin"
 
 organization := "com.yotaichino"
 
-version := "1.8.0"
+version := "1.8.1"
 
 scalaVersion := "2.13.7"
 gitbucketVersion := "4.42.1"
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies += "net.sourceforge.plantuml" % "plantuml-asl" % "1.2025.0"
 
-scalacOptions := Seq("-deprecation", "-feature", "-language:postfixOps", "-Ydelambdafy:method", "-target:jvm-17")
-javacOptions in compile ++= Seq("-target", "17", "-source", "17")
+scalacOptions := Seq("-deprecation", "-feature", "-language:postfixOps", "-Ydelambdafy:method", "-target:jvm-1.8")
+Compile / javacOptions ++= Seq("-target", "8", "-source", "17")
 
 useJCenter := true 

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ name := "gitbucket-plantuml-plugin"
 
 organization := "com.yotaichino"
 
-version := "1.8.0"
+version := "1.8.1"
 
 scalaVersion := "2.13.7"
-gitbucketVersion := "4.42.1"
+gitbucketVersion := "4.32.0"
 
 libraryDependencies ++= Seq(
   "org.scalatest"            %% "scalatest"          % "3.0.8" % "test"
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
 
 libraryDependencies += "net.sourceforge.plantuml" % "plantuml-asl" % "1.2025.0"
 
-scalacOptions := Seq("-deprecation", "-feature", "-language:postfixOps", "-Ydelambdafy:method", "-target:jvm-17")
-javacOptions in compile ++= Seq("-target", "17", "-source", "17")
+scalacOptions := Seq("-deprecation", "-feature", "-language:postfixOps", "-Ydelambdafy:method", "-target:jvm-1.8")
+Compile / javacOptions ++= Seq("-target", "8", "-source", "17")
 
-useJCenter := true 
+useJCenter := true

--- a/build.sbt
+++ b/build.sbt
@@ -2,25 +2,18 @@ name := "gitbucket-plantuml-plugin"
 
 organization := "com.yotaichino"
 
-version := "1.7.0"
+version := "1.8.0"
 
 scalaVersion := "2.13.7"
-gitbucketVersion := "4.37.0"
+gitbucketVersion := "4.42.1"
 
 libraryDependencies ++= Seq(
   "org.scalatest"            %% "scalatest"          % "3.0.8" % "test"
 )
 
-scalacOptions := Seq("-deprecation", "-feature", "-language:postfixOps", "-Ydelambdafy:method", "-target:jvm-1.8")
-javacOptions in compile ++= Seq("-target", "8", "-source", "8")
+libraryDependencies += "net.sourceforge.plantuml" % "plantuml-asl" % "1.2025.0"
+
+scalacOptions := Seq("-deprecation", "-feature", "-language:postfixOps", "-Ydelambdafy:method", "-target:jvm-17")
+javacOptions in compile ++= Seq("-target", "17", "-source", "17")
 
 useJCenter := true 
-
-lazy val downloadPlantuml = taskKey[Unit]("Download the PlantUML ASL Version.")
-downloadPlantuml := {
-  val url = "https://downloads.sourceforge.net/project/plantuml/1.2022.5/plantuml-jar-asl-1.2022.5.zip"
-  if (java.nio.file.Files.notExists(new File("lib/plantuml.jar").toPath())) {
-    println(url)
-    IO.unzipURL(new URL(url), new File("lib"))
-  }
-}

--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ name := "gitbucket-plantuml-plugin"
 
 organization := "com.yotaichino"
 
-version := "1.8.1"
+version := "1.8.0"
 
 scalaVersion := "2.13.7"
-gitbucketVersion := "4.32.0"
+gitbucketVersion := "4.36.0"
 
 libraryDependencies ++= Seq(
   "org.scalatest"            %% "scalatest"          % "3.0.8" % "test"

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -22,7 +22,8 @@ class Plugin extends gitbucket.core.plugin.Plugin {
     new Version("1.6.0"),
     new Version("1.6.1"),
     new Version("1.6.2"),
-    new Version("1.7.0")
+    new Version("1.7.0"),
+    new Version("1.8.0")
   )
 
   override def initialize(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Unit = {

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -23,7 +23,8 @@ class Plugin extends gitbucket.core.plugin.Plugin {
     new Version("1.6.1"),
     new Version("1.6.2"),
     new Version("1.7.0"),
-    new Version("1.8.0")
+    new Version("1.8.0"),
+    new Version("1.8.1")
   )
 
   override def initialize(registry: PluginRegistry, context: ServletContext, settings: SystemSettings): Unit = {

--- a/src/main/scala/com/yotaichino/gitbucket/plugins/plantuml/PlantUMLController.scala
+++ b/src/main/scala/com/yotaichino/gitbucket/plugins/plantuml/PlantUMLController.scala
@@ -28,9 +28,9 @@ trait PlantUMLControllerBase extends ControllerBase {
               contentType = "image/svg+xml"
               PlantUMLUtils.generateSVGImage(new String(content))
             }
-          case _ => unsupportedMediaType
+          case _ => unsupportedMediaType()
         }
-      } getOrElse NotFound
+      } getOrElse NotFound()
     }
   })
 

--- a/src/test/scala/plugin/PlantUMLUtilsSpec.scala
+++ b/src/test/scala/plugin/PlantUMLUtilsSpec.scala
@@ -5,7 +5,8 @@ class PlantUMLUtilsSpec extends FunSpec {
   describe("generateSVGImage") {
     it("should return a SVG image.") {
       val content = new String(PlantUMLUtils.generateSVGImage("@startuml\n@enduml"), "utf-8")
-      assert(content.startsWith("""<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg"""))
+      println(content)
+      assert(content.startsWith("""<svg xmlns="http://www.w3.org/2000/svg" """))
     }
     it("should return null when empty string") {
       assert(PlantUMLUtils.generateSVGImage("") == null)


### PR DESCRIPTION
Hello there,

thank you for providing this great add-on for Gitbucket. Unfortunately I've encountered a few *.puml files which could not be rendered with PlantUML 1.2022.5 but with later 1.2024.* versions. This version is prrovided by plugin version 1.7.0.
So I've decided to see, if I can provide an update in form of a PR.

This PR includes:
* Updated PlantUML ASL to 1.2025.0
* builds with Java 17 to JDK 1.8 target
* Requires at least GitBucket 4.36.0 or later (unfortunately I was not able to obtain all transitive dependencies for earlier Gitbucket versions).
* Reworked SBT build file to eliminate slash API warnings
* Tested with GitBucket 4.36.0 and GitBucket 4.39.0

Interestingly PlantUML changed the SVG character encoding from UTF-8 to u-sascii.

I would greatly appreciate if you would be able to review this proposal. Please advice if you see need for rework.
My proposal for this is to call it version 1.8.0.

Thank you!
